### PR TITLE
Update SDK version to 3.3.0

### DIFF
--- a/agrirouter-sdk-java-api/pom.xml
+++ b/agrirouter-sdk-java-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.agrirouter.api</groupId>
         <artifactId>agrirouter-sdk-java</artifactId>
-        <version>3.2.2</version>
+        <version>3.3.0</version>
     </parent>
     <name>AGRIROUTER SDK JAVA - API</name>
     <artifactId>agrirouter-sdk-java-api</artifactId>

--- a/agrirouter-sdk-java-convenience/pom.xml
+++ b/agrirouter-sdk-java-convenience/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.agrirouter.api</groupId>
         <artifactId>agrirouter-sdk-java</artifactId>
-        <version>3.2.2</version>
+        <version>3.3.0</version>
     </parent>
     <name>AGRIROUTER SDK JAVA - CONVENIENCE</name>
     <artifactId>agrirouter-sdk-java-convenience</artifactId>

--- a/agrirouter-sdk-java-impl/pom.xml
+++ b/agrirouter-sdk-java-impl/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.agrirouter.api</groupId>
         <artifactId>agrirouter-sdk-java</artifactId>
-        <version>3.2.2</version>
+        <version>3.3.0</version>
     </parent>
     <name>AGRIROUTER SDK JAVA - IMPL</name>
     <artifactId>agrirouter-sdk-java-impl</artifactId>

--- a/agrirouter-sdk-java-tests/pom.xml
+++ b/agrirouter-sdk-java-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-sdk-java</artifactId>
         <groupId>com.agrirouter.api</groupId>
-        <version>3.2.2</version>
+        <version>3.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>AGRIROUTER SDK JAVA - TESTS</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.agrirouter.api</groupId>
     <artifactId>agrirouter-sdk-java</artifactId>
-    <version>3.2.2</version>
+    <version>3.3.0</version>
     <packaging>pom</packaging>
 
     <name>AGRIROUTER SDK JAVA</name>


### PR DESCRIPTION
Bump parent POM version from 3.2.2 to 3.3.0 across all modules. This ensures consistency and incorporates the latest changes in the SDK dependencies and features.