### PR TITLE
Feature/happy path testing for documentation

### DIFF
--- a/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/documentation/OnboardingForTelemetryConnectionTest.java
+++ b/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/documentation/OnboardingForTelemetryConnectionTest.java
@@ -1,0 +1,59 @@
+package com.dke.data.agrirouter.documentation;
+
+import com.dke.data.agrirouter.api.enums.ApplicationType;
+import com.dke.data.agrirouter.api.enums.CertificationType;
+import com.dke.data.agrirouter.api.enums.Gateway;
+import com.dke.data.agrirouter.api.service.parameters.OnboardingParameters;
+import com.dke.data.agrirouter.impl.onboard.OnboardingServiceImpl;
+import com.dke.data.agrirouter.test.AbstractIntegrationTest;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class OnboardingForTelemetryConnectionTest extends AbstractIntegrationTest {
+
+    @Test
+    @Disabled("Please replace the placeholder for the registration code to run the test case.")
+    void givenValidRegistrationCodeWhenOnboardingNewTelemetryConnectionThenTheNewEndpointShouldBeCreated() {
+
+        // [1] Create onboarding parameters
+        // ============================================================
+        // Define the parameters used for onboarding, please be aware that the registration code needs
+        // to be replaced with an actual code to run the test case.
+        var onboardingParameters = new OnboardingParameters();
+        onboardingParameters.setRegistrationCode("REPLACE_ME_WITH_ACTUAL_REGISTRATION_CODE");
+        onboardingParameters.setApplicationId(communicationUnit.getApplicationId());
+        onboardingParameters.setCertificationVersionId(communicationUnit.getCertificationVersionId());
+        onboardingParameters.setCertificationType(CertificationType.P12);
+        onboardingParameters.setGatewayId(Gateway.REST.getKey());
+        onboardingParameters.setApplicationType(ApplicationType.APPLICATION);
+        onboardingParameters.setUuid(UUID.randomUUID().toString());
+
+        // [2] Onboard the new telemetry connection
+        // ============================================================
+        // Use the onboarding service to onboard the new telemetry connection.
+        var onboardingService = new OnboardingServiceImpl(communicationUnit.getEnvironment());
+        final var onboardingResponse = onboardingService.onboard(onboardingParameters);
+
+        // [3] Validate the onboarding response
+        // ============================================================
+        // Check if the onboarding response contains all necessary information. This is just necessary within the tests, but not
+        // needed in production code.
+        assertNotNull(onboardingResponse);
+        assertNotNull(onboardingResponse.getCapabilityAlternateId());
+        assertNotNull(onboardingResponse.getDeviceAlternateId());
+        assertNotNull(onboardingResponse.getSensorAlternateId());
+        assertNotNull(onboardingResponse.getAuthentication());
+        assertNotNull(onboardingResponse.getAuthentication().getCertificate());
+        assertNotNull(onboardingResponse.getAuthentication().getSecret());
+        assertNotNull(onboardingResponse.getAuthentication().getType());
+        assertNotNull(onboardingResponse.getConnectionCriteria());
+        assertNotNull(onboardingResponse.getConnectionCriteria().getMeasures());
+        assertNotNull(onboardingResponse.getConnectionCriteria().getCommands());
+    }
+
+
+}

--- a/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/AbstractIntegrationTest.java
+++ b/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/AbstractIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.dke.data.agrirouter.test;
 
+import com.dke.data.agrirouter.api.env.Environment;
+import com.dke.data.agrirouter.api.env.QA;
 import org.apache.commons.lang3.NotImplementedException;
 
 import java.util.concurrent.TimeUnit;
@@ -51,6 +53,12 @@ public abstract class AbstractIntegrationTest {
                 public String getCertificationVersionId() {
                     return "96c2c3e8-5e30-11ef-a95b-d2e1bbd0b244";
                 }
+
+                @Override
+                public Environment getEnvironment() {
+                    return new QA() {
+                    };
+                }
             };
 
     /**
@@ -67,6 +75,12 @@ public abstract class AbstractIntegrationTest {
                 @Override
                 public String getCertificationVersionId() {
                     return "4dc7a506-5e31-11ef-a95b-d2e1bbd0b244";
+                }
+
+                @Override
+                public Environment getEnvironment() {
+                    return new QA() {
+                    };
                 }
 
                 @Override
@@ -133,6 +147,12 @@ public abstract class AbstractIntegrationTest {
                 @Override
                 public String getCertificationVersionId() {
                     return "e743930a-5e31-11ef-a95b-d2e1bbd0b244";
+                }
+
+                @Override
+                public Environment getEnvironment() {
+                    return new QA() {
+                    };
                 }
 
                 @Override
@@ -203,6 +223,13 @@ public abstract class AbstractIntegrationTest {
          * @return -
          */
         public abstract String getCertificationVersionId();
+
+        /**
+         * Environment for the application.
+         *
+         * @return -
+         */
+        public abstract Environment getEnvironment();
 
         /**
          * Private key for the application.

--- a/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/fixture/CommunicationUnitFixture.java
+++ b/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/fixture/CommunicationUnitFixture.java
@@ -7,7 +7,6 @@ import com.dke.data.agrirouter.api.enums.ApplicationType;
 import com.dke.data.agrirouter.api.enums.CertificationType;
 import com.dke.data.agrirouter.api.enums.ContentMessageType;
 import com.dke.data.agrirouter.api.enums.Gateway;
-import com.dke.data.agrirouter.api.env.QA;
 import com.dke.data.agrirouter.api.service.onboard.OnboardingService;
 import com.dke.data.agrirouter.api.service.parameters.OnboardingParameters;
 import com.dke.data.agrirouter.api.service.parameters.SetCapabilitiesParameters;

--- a/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/fixture/CommunicationUnitFixture.java
+++ b/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/fixture/CommunicationUnitFixture.java
@@ -38,8 +38,7 @@ class CommunicationUnitFixture extends AbstractIntegrationTest {
     @Test
     @Disabled("Please replace the placeholder for the registration code to run the test case.")
     void onboardCommunicationUnitAndSaveToFile() throws IOException {
-        OnboardingService onboardingService = new OnboardingServiceImpl(new QA() {
-        });
+        OnboardingService onboardingService = new OnboardingServiceImpl(communicationUnit.getEnvironment());
         OnboardingParameters onboardingParameters = new OnboardingParameters();
         onboardingParameters.setRegistrationCode("8908462691");
         onboardingParameters.setApplicationId(communicationUnit.getApplicationId());

--- a/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/fixture/FarmingSoftwareFixture.java
+++ b/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/fixture/FarmingSoftwareFixture.java
@@ -3,7 +3,6 @@ package com.dke.data.agrirouter.test.fixture;
 import com.dke.data.agrirouter.api.dto.onboard.OnboardingResponse;
 import com.dke.data.agrirouter.api.enums.CertificationType;
 import com.dke.data.agrirouter.api.enums.Gateway;
-import com.dke.data.agrirouter.api.env.QA;
 import com.dke.data.agrirouter.api.service.onboard.secured.OnboardingService;
 import com.dke.data.agrirouter.api.service.parameters.SecuredOnboardingParameters;
 import com.dke.data.agrirouter.impl.onboard.secured.OnboardingServiceImpl;

--- a/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/fixture/FarmingSoftwareFixture.java
+++ b/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/fixture/FarmingSoftwareFixture.java
@@ -34,8 +34,7 @@ class FarmingSoftwareFixture extends AbstractIntegrationTest {
     @Test
     @Disabled("Please replace the placeholder for the registration code to run the test case.")
     void onboardFarmingSoftwareAndSaveToFile() throws IOException {
-        OnboardingService onboardingService = new OnboardingServiceImpl(new QA() {
-        });
+        OnboardingService onboardingService = new OnboardingServiceImpl(farmingSoftware.getEnvironment());
         SecuredOnboardingParameters onboardingParameters = new SecuredOnboardingParameters();
         onboardingParameters.setRegistrationCode("2067663604");
         onboardingParameters.setApplicationId(farmingSoftware.getApplicationId());

--- a/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/fixture/MqttCommunicationUnitFixture.java
+++ b/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/fixture/MqttCommunicationUnitFixture.java
@@ -6,7 +6,6 @@ import com.dke.data.agrirouter.api.enums.ApplicationType;
 import com.dke.data.agrirouter.api.enums.CertificationType;
 import com.dke.data.agrirouter.api.enums.ContentMessageType;
 import com.dke.data.agrirouter.api.enums.Gateway;
-import com.dke.data.agrirouter.api.env.QA;
 import com.dke.data.agrirouter.api.service.onboard.OnboardingService;
 import com.dke.data.agrirouter.api.service.parameters.OnboardingParameters;
 import com.dke.data.agrirouter.api.service.parameters.SetCapabilitiesParameters;

--- a/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/fixture/MqttCommunicationUnitFixture.java
+++ b/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/fixture/MqttCommunicationUnitFixture.java
@@ -48,8 +48,7 @@ class MqttCommunicationUnitFixture extends AbstractIntegrationTest {
     @Test
     //@Disabled("Please replace the placeholder for the registration code to run the test case.")
     void onboardCommunicationUnitAndSaveToFile() throws Throwable {
-        OnboardingService onboardingService = new OnboardingServiceImpl(new QA() {
-        });
+        OnboardingService onboardingService = new OnboardingServiceImpl(communicationUnit.getEnvironment());
         OnboardingParameters onboardingParameters = new OnboardingParameters();
         onboardingParameters.setRegistrationCode("4822479417");
         onboardingParameters.setApplicationId(communicationUnit.getApplicationId());
@@ -73,12 +72,10 @@ class MqttCommunicationUnitFixture extends AbstractIntegrationTest {
         OnboardingResponseRepository.save(
                 OnboardingResponseRepository.Identifier.MQTT_COMMUNICATION_UNIT, onboardingResponse);
 
-        MqttClientService mqttClientService = new MqttClientService(new QA() {
-        });
+        MqttClientService mqttClientService = new MqttClientService(communicationUnit.getEnvironment());
         IMqttClient mqttClient = mqttClientService.create(onboardingResponse);
 
-        MqttOptionService mqttOptionService = new MqttOptionService(new QA() {
-        });
+        MqttOptionService mqttOptionService = new MqttOptionService(communicationUnit.getEnvironment());
         mqttClient.setCallback(new InternalCallback());
         mqttClient.connect(mqttOptionService.createMqttConnectOptions(onboardingResponse));
         mqttClient.subscribe(onboardingResponse.getConnectionCriteria().getCommands());

--- a/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/fixture/TelemetryPlatformFixture.java
+++ b/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/fixture/TelemetryPlatformFixture.java
@@ -3,7 +3,6 @@ package com.dke.data.agrirouter.test.fixture;
 import com.dke.data.agrirouter.api.dto.onboard.OnboardingResponse;
 import com.dke.data.agrirouter.api.enums.CertificationType;
 import com.dke.data.agrirouter.api.enums.Gateway;
-import com.dke.data.agrirouter.api.env.QA;
 import com.dke.data.agrirouter.api.service.onboard.secured.OnboardingService;
 import com.dke.data.agrirouter.api.service.parameters.SecuredOnboardingParameters;
 import com.dke.data.agrirouter.impl.onboard.secured.OnboardingServiceImpl;

--- a/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/fixture/TelemetryPlatformFixture.java
+++ b/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/fixture/TelemetryPlatformFixture.java
@@ -31,8 +31,7 @@ class TelemetryPlatformFixture extends AbstractIntegrationTest {
     @Test
     @Disabled("Please replace the placeholder for the registration code to run the test case.")
     void onboardTelemetryPlatformAndSaveToFile() throws IOException {
-        OnboardingService onboardingService = new OnboardingServiceImpl(new QA() {
-        });
+        OnboardingService onboardingService = new OnboardingServiceImpl(telemetryPlatform.getEnvironment());
         SecuredOnboardingParameters onboardingParameters = new SecuredOnboardingParameters();
         onboardingParameters.setRegistrationCode("8530975704");
         onboardingParameters.setApplicationId(telemetryPlatform.getApplicationId());

--- a/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/messaging/mqtt/PingServiceTest.java
+++ b/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/messaging/mqtt/PingServiceTest.java
@@ -2,7 +2,6 @@ package com.dke.data.agrirouter.test.messaging.mqtt;
 
 import agrirouter.response.Response;
 import com.dke.data.agrirouter.api.dto.messaging.FetchMessageResponse;
-import com.dke.data.agrirouter.api.env.QA;
 import com.dke.data.agrirouter.api.service.messaging.encoding.DecodeMessageService;
 import com.dke.data.agrirouter.api.service.messaging.mqtt.PingService;
 import com.dke.data.agrirouter.api.service.parameters.PingParameters;

--- a/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/messaging/mqtt/PingServiceTest.java
+++ b/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/messaging/mqtt/PingServiceTest.java
@@ -38,12 +38,10 @@ class PingServiceTest extends AbstractIntegrationTest {
     void sendHealthMessageToPingEndpoint() throws Throwable {
         var onboardingResponse = OnboardingResponseRepository.read(OnboardingResponseRepository.Identifier.MQTT_COMMUNICATION_UNIT);
 
-        var mqttClientService = new MqttClientService(new QA() {
-        });
+        var mqttClientService = new MqttClientService(communicationUnit.getEnvironment());
         var mqttClient = mqttClientService.create(onboardingResponse);
 
-        var mqttOptionService = new MqttOptionService(new QA() {
-        });
+        var mqttOptionService = new MqttOptionService(communicationUnit.getEnvironment());
         mqttClient.setCallback(new PingServiceTest.InternalCallback());
         mqttClient.connect(mqttOptionService.createMqttConnectOptions(onboardingResponse));
         mqttClient.subscribe(onboardingResponse.getConnectionCriteria().getCommands());

--- a/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/messaging/rest/SetSubscriptionServiceTest.java
+++ b/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/messaging/rest/SetSubscriptionServiceTest.java
@@ -3,7 +3,6 @@ package com.dke.data.agrirouter.test.messaging.rest;
 import com.dke.data.agrirouter.api.cancellation.DefaultCancellationToken;
 import com.dke.data.agrirouter.api.enums.ContentMessageType;
 import com.dke.data.agrirouter.api.enums.SystemMessageType;
-import com.dke.data.agrirouter.api.env.QA;
 import com.dke.data.agrirouter.api.service.messaging.encoding.DecodeMessageService;
 import com.dke.data.agrirouter.api.service.messaging.http.FetchMessageService;
 import com.dke.data.agrirouter.api.service.messaging.http.SetSubscriptionService;
@@ -31,8 +30,7 @@ class SetSubscriptionServiceTest extends AbstractIntegrationTest {
     @Test
     void givenValidEndpointWhenSendingSubscriptionsTheSubscriptionMessageShouldBeAccepted()
             throws Throwable {
-        SetSubscriptionService setSubscriptionService = new SetSubscriptionServiceImpl(new QA() {
-        });
+        SetSubscriptionService setSubscriptionService = new SetSubscriptionServiceImpl(farmingSoftware.getEnvironment());
 
         var parameters = new SetSubscriptionParameters();
         parameters.setOnboardingResponse(read(Identifier.FARMING_SOFTWARE));
@@ -70,8 +68,7 @@ class SetSubscriptionServiceTest extends AbstractIntegrationTest {
     @Test
     void givenValidEndpointWhenSendingInvalidSubscriptionsTheSubscriptionMessageShouldNotBeAccepted()
             throws Throwable {
-        SetSubscriptionService setSubscriptionService = new SetSubscriptionServiceImpl(new QA() {
-        });
+        SetSubscriptionService setSubscriptionService = new SetSubscriptionServiceImpl(farmingSoftware.getEnvironment());
 
         var parameters = new SetSubscriptionParameters();
         parameters.setOnboardingResponse(read(Identifier.FARMING_SOFTWARE));

--- a/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/onboarding/AuthorizationRequestServiceTest.java
+++ b/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/onboarding/AuthorizationRequestServiceTest.java
@@ -1,7 +1,6 @@
 package com.dke.data.agrirouter.test.onboarding;
 
 import com.dke.data.agrirouter.api.enums.SecuredOnboardingResponseType;
-import com.dke.data.agrirouter.api.env.QA;
 import com.dke.data.agrirouter.api.exception.IllegalParameterDefinitionException;
 import com.dke.data.agrirouter.api.service.onboard.secured.AuthorizationRequestService;
 import com.dke.data.agrirouter.api.service.parameters.AuthorizationRequestParameters;
@@ -21,8 +20,7 @@ public class AuthorizationRequestServiceTest extends AbstractIntegrationTest {
     @Test
     void givenValidParameterWhenCreatingTheUrlThenTheUrlShouldBeGeneratedForFarmingSoftware() {
         AuthorizationRequestService authorizationRequestService =
-                new AuthorizationRequestServiceImpl(new QA() {
-                });
+                new AuthorizationRequestServiceImpl(farmingSoftware.getEnvironment());
         var authorizationRequestParameters =
                 new AuthorizationRequestParameters();
         authorizationRequestParameters.setApplicationId(farmingSoftware.getApplicationId());
@@ -40,8 +38,7 @@ public class AuthorizationRequestServiceTest extends AbstractIntegrationTest {
     @Test
     void givenValidParameterWhenCreatingTheUrlThenTheUrlShouldBeGeneratedForTelemetryPlatform() {
         AuthorizationRequestService authorizationRequestService =
-                new AuthorizationRequestServiceImpl(new QA() {
-                });
+                new AuthorizationRequestServiceImpl(telemetryPlatform.getEnvironment());
         var authorizationRequestParameters =
                 new AuthorizationRequestParameters();
         authorizationRequestParameters.setApplicationId(telemetryPlatform.getApplicationId());
@@ -59,8 +56,7 @@ public class AuthorizationRequestServiceTest extends AbstractIntegrationTest {
     @Test
     void givenInvalidParameterWhenCreatingTheUrlThenTheUrlShouldBeGenerated() {
         AuthorizationRequestService authorizationRequestService =
-                new AuthorizationRequestServiceImpl(new QA() {
-                });
+                new AuthorizationRequestServiceImpl(telemetryPlatform.getEnvironment());
         var authorizationRequestParameters =
                 new AuthorizationRequestParameters();
         authorizationRequestParameters.setResponseType(SecuredOnboardingResponseType.ONBOARD);

--- a/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/onboarding/OnboardingWithErrorMessageTest.java
+++ b/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/onboarding/OnboardingWithErrorMessageTest.java
@@ -3,8 +3,6 @@ package com.dke.data.agrirouter.test.onboarding;
 import com.dke.data.agrirouter.api.enums.ApplicationType;
 import com.dke.data.agrirouter.api.enums.CertificationType;
 import com.dke.data.agrirouter.api.enums.Gateway;
-import com.dke.data.agrirouter.api.env.Environment;
-import com.dke.data.agrirouter.api.env.QA;
 import com.dke.data.agrirouter.api.exception.OnboardingException;
 import com.dke.data.agrirouter.api.service.onboard.OnboardingService;
 import com.dke.data.agrirouter.api.service.parameters.OnboardingParameters;

--- a/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/onboarding/OnboardingWithErrorMessageTest.java
+++ b/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/onboarding/OnboardingWithErrorMessageTest.java
@@ -21,7 +21,7 @@ class OnboardingWithErrorMessageTest extends AbstractIntegrationTest {
     @Test
     void
     givenInvalidRegistrationCodeWhenSendingTheOnboardingRequestThenThereShouldBeAnOnboardingExceptionWithFilledErrorMessage() {
-        OnboardingService onboardingService = new OnboardingServiceImpl(getEnv());
+        OnboardingService onboardingService = new OnboardingServiceImpl(communicationUnit.getEnvironment());
         var onboardingParameters = new OnboardingParameters();
         onboardingParameters.setApplicationMessageId(MessageIdService.generateMessageId());
         onboardingParameters.setApplicationType(ApplicationType.APPLICATION);
@@ -41,8 +41,4 @@ class OnboardingWithErrorMessageTest extends AbstractIntegrationTest {
                 "Bearer not found.", onboardingException.getOnboardingError().getError().getMessage());
     }
 
-    private Environment getEnv() {
-        return new QA() {
-        };
-    }
 }

--- a/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/onboarding/SecuredOnboardingServiceTest.java
+++ b/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/onboarding/SecuredOnboardingServiceTest.java
@@ -2,7 +2,6 @@ package com.dke.data.agrirouter.test.onboarding;
 
 import com.dke.data.agrirouter.api.enums.CertificationType;
 import com.dke.data.agrirouter.api.enums.Gateway;
-import com.dke.data.agrirouter.api.env.QA;
 import com.dke.data.agrirouter.api.exception.OnboardingException;
 import com.dke.data.agrirouter.api.service.onboard.secured.OnboardingService;
 import com.dke.data.agrirouter.api.service.parameters.SecuredOnboardingParameters;

--- a/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/onboarding/SecuredOnboardingServiceTest.java
+++ b/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/onboarding/SecuredOnboardingServiceTest.java
@@ -24,8 +24,7 @@ class SecuredOnboardingServiceTest extends AbstractIntegrationTest {
     @Test
     void
     givenInvalidRegistrationCodeThereShouldBeAnOnboardingExceptionWhenSendingAnOnboardingRequest() {
-        OnboardingService onboardingService = new OnboardingServiceImpl(new QA() {
-        });
+        OnboardingService onboardingService = new OnboardingServiceImpl(farmingSoftware.getEnvironment());
         var onboardingParameters = new SecuredOnboardingParameters();
         onboardingParameters.setRegistrationCode("SOME_INVALID_REGISTRATION_CODE");
         onboardingParameters.setApplicationId(farmingSoftware.getApplicationId());
@@ -42,8 +41,7 @@ class SecuredOnboardingServiceTest extends AbstractIntegrationTest {
     @Disabled("Please replace the placeholder for the registration code to run the test case.")
     void
     givenValidRegistrationCodeThereShouldBeAnOnboardingResponseWhenSendingAnOnboardingRequestForFarmingSoftware() {
-        OnboardingService onboardingService = new OnboardingServiceImpl(new QA() {
-        });
+        OnboardingService onboardingService = new OnboardingServiceImpl(farmingSoftware.getEnvironment());
         var onboardingParameters = new SecuredOnboardingParameters();
         onboardingParameters.setRegistrationCode("PLEASE_REPLACE_ME");
         onboardingParameters.setApplicationId(farmingSoftware.getApplicationId());
@@ -71,8 +69,7 @@ class SecuredOnboardingServiceTest extends AbstractIntegrationTest {
     @Disabled("Please replace the placeholder for the registration code to run the test case.")
     void
     givenValidRegistrationCodeThereShouldBeAnOnboardingResponseWhenSendingAnOnboardingRequestForTelemetryPlatform() {
-        OnboardingService onboardingService = new OnboardingServiceImpl(new QA() {
-        });
+        OnboardingService onboardingService = new OnboardingServiceImpl(farmingSoftware.getEnvironment());
         var onboardingParameters = new SecuredOnboardingParameters();
         onboardingParameters.setRegistrationCode("PLEASE_REPLACE_ME");
         onboardingParameters.setApplicationId(telemetryPlatform.getApplicationId());

--- a/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/usecase/SendAndReceiveChunkedMessagesTest.java
+++ b/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/usecase/SendAndReceiveChunkedMessagesTest.java
@@ -68,8 +68,7 @@ class SendAndReceiveChunkedMessagesTest extends AbstractIntegrationTest {
             throws Throwable {
         // [1] Fetch all the messages within the feed. The number of headers should match the number of
         // chunks sent.
-        final var messageQueryService = new MessageQueryServiceImpl(new QA() {
-        });
+        final var messageQueryService = new MessageQueryServiceImpl(communicationUnit.getEnvironment());
         final var messageQueryParameters = new MessageQueryParameters();
         final var recipient =
                 OnboardingResponseRepository.read(
@@ -135,8 +134,7 @@ class SendAndReceiveChunkedMessagesTest extends AbstractIntegrationTest {
                         .map(feedMessage -> feedMessage.getHeader().getMessageId())
                         .collect(Collectors.toList());
         final var messageConfirmationService =
-                new MessageConfirmationServiceImpl(new QA() {
-                });
+                new MessageConfirmationServiceImpl(communicationUnit.getEnvironment());
         final var messageConfirmationParameters =
                 new MessageConfirmationParameters();
         messageConfirmationParameters.setOnboardingResponse(recipient);
@@ -271,8 +269,7 @@ class SendAndReceiveChunkedMessagesTest extends AbstractIntegrationTest {
                 OnboardingResponseRepository.read(
                         OnboardingResponseRepository.Identifier.COMMUNICATION_UNIT);
         final var messageHeaderQueryService =
-                new MessageHeaderQueryServiceImpl(new QA() {
-                });
+                new MessageHeaderQueryServiceImpl(communicationUnit.getEnvironment());
 
         // [1] Clean the outbox of the endpoint.
         fetchMessageService.fetch(

--- a/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/usecase/SendAndReceiveChunkedMessagesTest.java
+++ b/agrirouter-sdk-java-tests/src/test/java/com/dke/data/agrirouter/test/usecase/SendAndReceiveChunkedMessagesTest.java
@@ -8,7 +8,6 @@ import com.dke.data.agrirouter.api.dto.encoding.DecodeMessageResponse;
 import com.dke.data.agrirouter.api.dto.messaging.FetchMessageResponse;
 import com.dke.data.agrirouter.api.enums.ContentMessageType;
 import com.dke.data.agrirouter.api.enums.SystemMessageType;
-import com.dke.data.agrirouter.api.env.QA;
 import com.dke.data.agrirouter.api.service.messaging.encoding.DecodeMessageService;
 import com.dke.data.agrirouter.api.service.messaging.encoding.EncodeMessageService;
 import com.dke.data.agrirouter.api.service.messaging.http.FetchMessageService;


### PR DESCRIPTION
This pull request introduces a new integration test for onboarding telemetry connections and refactors the test codebase to dynamically use environment configurations instead of hardcoding `QA`. By centralizing environment configuration logic, the changes improve maintainability and reusability.

### New Test Addition:
* Added a new test class `OnboardingForTelemetryConnectionTest` to validate the onboarding process for telemetry connections. The test includes parameter creation, onboarding execution, and response validation.

### Refactoring for Environment Configuration:
* **Abstract Integration Test Enhancements:**
  - Added a new abstract method `getEnvironment()` in `AbstractIntegrationTest.Application` to dynamically provide environment configurations. Implementations now return an instance of `QA`. [[1]](diffhunk://#diff-02d8624c95a58e7386e9efc32e8edf48043f5ecca26745d6a945e41cade294ddR3-R4) [[2]](diffhunk://#diff-02d8624c95a58e7386e9efc32e8edf48043f5ecca26745d6a945e41cade294ddR56-R61) [[3]](diffhunk://#diff-02d8624c95a58e7386e9efc32e8edf48043f5ecca26745d6a945e41cade294ddR80-R85) [[4]](diffhunk://#diff-02d8624c95a58e7386e9efc32e8edf48043f5ecca26745d6a945e41cade294ddR152-R157) [[5]](diffhunk://#diff-02d8624c95a58e7386e9efc32e8edf48043f5ecca26745d6a945e41cade294ddR227-R233)

* **Fixture and Service Tests Updates:**
  - Replaced hardcoded `new QA()` instances with calls to the `getEnvironment()` method in various test fixtures and service tests, including:
    - `CommunicationUnitFixture`
    - `FarmingSoftwareFixture`
    - `MqttCommunicationUnitFixture` [[1]](diffhunk://#diff-fc64e89ce1e013d00e30e5b095fad8e7ecfa98664d7023dbf34cfc2edb44e0f6L51-R50) [[2]](diffhunk://#diff-fc64e89ce1e013d00e30e5b095fad8e7ecfa98664d7023dbf34cfc2edb44e0f6L76-R77)
    - `TelemetryPlatformFixture`
    - `PingServiceTest`
    - `SetSubscriptionServiceTest` [[1]](diffhunk://#diff-8ff9df73f311eabe20063bbbb554c3f15f39032ee8ba3db383ba4011f60d210dL34-R33) [[2]](diffhunk://#diff-8ff9df73f311eabe20063bbbb554c3f15f39032ee8ba3db383ba4011f60d210dL73-R71)
    - `AuthorizationRequestServiceTest` [[1]](diffhunk://#diff-eb363765f66a99a0aa4605c2a47c4cf78ae7c8723fdb93c7c10e754533ac6481L24-R23) [[2]](diffhunk://#diff-eb363765f66a99a0aa4605c2a47c4cf78ae7c8723fdb93c7c10e754533ac6481L43-R41)

* **Unused Imports Removal:**
  - Removed unused imports of `QA` from several test files to clean up the codebase. [[1]](diffhunk://#diff-586450dc5ac90aa356fc14b717ed956e59b607cec5312bc4de35069472a37830L10) [[2]](diffhunk://#diff-5817de63a90c3d60b45ec0013f9599f98539fff6b8554b4fea7e1d73359d5144L6) [[3]](diffhunk://#diff-fc64e89ce1e013d00e30e5b095fad8e7ecfa98664d7023dbf34cfc2edb44e0f6L9) [[4]](diffhunk://#diff-35ab681c047c94d5962af8f86b0eaa1ea367fdd7565ce941af606c41a126b669L6) [[5]](diffhunk://#diff-c1cbce8d729b4ba8e01e6950869726659477ea0b621116f06a9b7dff5c08ac2eL5) [[6]](diffhunk://#diff-8ff9df73f311eabe20063bbbb554c3f15f39032ee8ba3db383ba4011f60d210dL6) [[7]](diffhunk://#diff-eb363765f66a99a0aa4605c2a47c4cf78ae7c8723fdb93c7c10e754533ac6481L4)